### PR TITLE
Add dry-run option to parse template

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A very simple cli tool that will upload an ecs task and optionally update a service to reference it.
 
-Designed as a partner tool to https://github.com/buildkite/ecs-run-task and shares the same task definition parser with environment substitution. 
+Designed as a partner tool to https://github.com/buildkite/ecs-run-task and shares the same task definition parser with environment substitution.
 
 ##### example
 
@@ -10,7 +10,7 @@ install it
 ```bash
 go get -u github.com/99designs/ecs-upload-task
 
-or 
+or
 
 curl -L --fail -o /usr/bin/ecs-upload-task \
   <release from https://github.com/99designs/ecs-upload-task/releases>
@@ -32,7 +32,15 @@ containerDefinitions:
 
 ```
 
-then the initial task definition
+then take it for a dry-run to validate that the template is parsed successfully.
+
+```bash
+ecs-upload-task --file taskdefinition.yml --dry-run
+Template taskdefinition.yml is parsed successfully
+```
+
+then register the task definition
+
 ```bash
 ecs-upload-task --file taskdefinition.yml
 ```
@@ -40,9 +48,10 @@ ecs-upload-task --file taskdefinition.yml
 Create a new ECS service referencing the task definition. Service templates can use the family name without the version, simply `hello-world` is enough.
 
 
-later, in your automated CI pipeline you can deploy by simply:
+Later, in your automated CI pipeline you can deploy by simply:
+
 ```bash
-export IMAGE_NAME=99designs/hello-world:$FRESH_BUILD_NUMBER 
+export IMAGE_NAME=99designs/hello-world:$FRESH_BUILD_NUMBER
 ecs-upload-task --file taskdefinition.yml --service hello-world-2017-05-15-10-45
 
 2017/11/14 18:02:32 Registering a task for hello-world


### PR DESCRIPTION
## Problem

We do not run `ecs-upload-task` on PR build and often the issue with invalid template surface too late on master build. We also would like to quickly validate the template before uploading to AWS. 

## Proposal

This commit adds a new dry-run option to the `ecs-upload-task` command.

### Usage
```
ecs-upload-task --file taskdefinition --dry-run
```

It will return either a successful message 
```
Template taskdefinition.yml is parsed successfully     
```

or a parsed error

```
Unable to parse task definition: json: cannot unmarshal number into Go struct field ContainerDefinition.ContainerDefinitions.DockerLabels of type string   
```

This change will hopefully enable faster feedback loop for CI build on pull request.