### PR TITLE
Create multi-arch release and update instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,9 @@
 VERSION=$(shell git describe --tags --candidates=1 --dirty 2>/dev/null || echo "dev")
 FLAGS=-X main.Version=$(VERSION)
 
-all: darwin linux windows
-
-darwin:
-	GOOS=darwin GOARCH=amd64 go build -ldflags="$(FLAGS)" -o bin/ecs-upload-task-osx-$(VERSION) .
-
-linux:
-	GOOS=linux GOARCH=amd64 go build -ldflags="$(FLAGS)" -o bin/ecs-upload-task-linux-$(VERSION) .
-
-windows:
-	GOOS=windows GOARCH=amd64 go build -ldflags="$(FLAGS)" -o bin/ecs-upload-task-win-$(VERSION) .
-
 release-multi-arch: clean
 	mkdir -p bin
-	gox -os="linux darwin windows" -arch="amd64 arm64" -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}"      
+	gox -os="linux darwin windows" -arch="amd64 arm64" -ldflags="$(FLAGS)" -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}"      
 
 clean:
 	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=$(shell git describe --tags --candidates=1 --dirty 2>/dev/null || echo "dev")
 FLAGS=-X main.Version=$(VERSION)
 
-release-multi-arch: clean
+all: clean
 	mkdir -p bin
 	gox -os="linux darwin windows" -arch="amd64 arm64" -ldflags="$(FLAGS)" -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}"      
 

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@ linux:
 windows:
 	GOOS=windows GOARCH=amd64 go build -ldflags="$(FLAGS)" -o bin/ecs-upload-task-win-$(VERSION) .
 
-release-multi-arch:
+release-multi-arch: clean
 	mkdir -p bin
 	gox -os="linux darwin windows" -arch="amd64 arm64" -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}"      
 
 clean:
-	rm -f bin/*
+	rm -rf bin
+	

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,10 @@ linux:
 
 windows:
 	GOOS=windows GOARCH=amd64 go build -ldflags="$(FLAGS)" -o bin/ecs-upload-task-win-$(VERSION) .
+
+release-multi-arch:
+	mkdir -p bin
+	gox -os="linux darwin windows" -arch="amd64 arm64" -output="./bin/{{.Dir}}_{{.OS}}_{{.Arch}}"      
+
+clean:
+	rm -f bin/*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/99designs/ecs-upload-task
 
-go 1.12
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.21.1

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Designed as a partner tool to https://github.com/buildkite/ecs-run-task and shar
 
 install it
 ```bash
-go install -u github.com/99designs/ecs-upload-task
+go install github.com/99designs/ecs-upload-task@latest
 
 or
 
@@ -69,7 +69,7 @@ ecs-upload-task --file taskdefinition.yml --service hello-world-2017-05-15-10-45
 With the uptake of M1 Macs amongst devs, we need to create builds for multiple CPU architectures to ensure compatability across all devices. This uses [`gox`](https://github.com/mitchellh/gox) to do the multi-arch builds. This can be installed by
 
 ```
-go install github.com/mitchellh/gox
+go install github.com/mitchellh/gox@latest
 ```
 
 Following this:
@@ -83,11 +83,10 @@ $ git push --tags
 
 2. Create the binaries:
 
+
 ```
-$ make clean
-$ make release-multi-arch
+$ make
 ```
-Note: If you don't want to make a multi-arch build you can skip the `gox` install and run `make all` instead.
 
 3. Go to https://github.com/99designs/ecs-upload-task/releases/new
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Designed as a partner tool to https://github.com/buildkite/ecs-run-task and shar
 
 install it
 ```bash
-go get -u github.com/99designs/ecs-upload-task
+go install -u github.com/99designs/ecs-upload-task
 
 or
 
@@ -63,3 +63,35 @@ ecs-upload-task --file taskdefinition.yml --service hello-world-2017-05-15-10-45
 2017/11/14 18:03:48 (service hello-world-2017-05-15-10-45) has stopped 1 running tasks: (task a3e3a91b-be05-4092-bcf6-47f2075933af).
 
 ```
+
+## Creating a new multi-arch release
+
+With the uptake of M1 Macs amongst devs, we need to create builds for multiple CPU architectures to ensure compatability across all devices. This uses [`gox`](https://github.com/mitchellh/gox) to do the multi-arch builds. This can be installed by
+
+```
+go install github.com/mitchellh/gox
+```
+
+Following this:
+
+1. Check out the the commit you want to create a release for, and tag it with appropriate semver convention:
+
+```
+$ git tag vx.x.x
+$ git push --tags
+```
+
+2. Create the binaries:
+
+```
+$ make clean
+$ make release-multi-arch
+```
+Note: If you don't want to make a multi-arch build you can skip the `gox` install and run `make all` instead.
+
+3. Go to https://github.com/99designs/ecs-upload-task/releases/new
+
+4. Select the tag version you just created
+
+5. Attach the binaries from `./bin/*`
+

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
-#### ecs-upload-task
+# `ecs-upload-task`
 
 A very simple cli tool that will upload an ecs task and optionally update a service to reference it.
 
 Designed as a partner tool to https://github.com/buildkite/ecs-run-task and shares the same task definition parser with environment substitution.
 
-##### example
+## Example
 
-install it
+Install it
 ```bash
 go install github.com/99designs/ecs-upload-task@latest
 
@@ -16,7 +16,7 @@ curl -L --fail -o /usr/bin/ecs-upload-task \
   <release from https://github.com/99designs/ecs-upload-task/releases>
 ```
 
-taskdefinition.yml
+`taskdefinition.yml`
 ```yaml
 family: hello-world
 containerDefinitions:
@@ -64,15 +64,7 @@ ecs-upload-task --file taskdefinition.yml --service hello-world-2017-05-15-10-45
 
 ```
 
-## Creating a new multi-arch release
-
-With the uptake of M1 Macs amongst devs, we need to create builds for multiple CPU architectures to ensure compatability across all devices. This uses [`gox`](https://github.com/mitchellh/gox) to do the multi-arch builds. This can be installed by
-
-```
-go install github.com/mitchellh/gox@latest
-```
-
-Following this:
+## Creating a new release
 
 1. Check out the the commit you want to create a release for, and tag it with appropriate semver convention:
 
@@ -83,6 +75,14 @@ $ git push --tags
 
 2. Create the binaries:
 
+Binaries are compiled using [`gox`](https://github.com/mitchellh/gox). This provides a simple way to compile for multiple CPU architectures (`amd64`, `arm64`), which allows us to provide support for devices such as M1 Macs.
+
+`gox` can be installed via `go install`
+
+```
+go install github.com/mitchellh/gox@latest
+```
+Then simply run the `Makefile` to compile.
 
 ```
 $ make


### PR DESCRIPTION
Add multi-arch build and bump go version to allow compatibility with multi-arch docker builds.

This PR uses `gox` to create a multi-arch build for ecs-upload-task and uploads the makefile accordingly.
It has upgraded to Go 1.16 to match ecs-run-task, as binaries of newer Go versions also seem to behave better when running on M1 Macs
It also adds release instructions to the Readme for future uses

**Context**
Some teams still use `ecs-upload-task` to deploy ECS changes both in CI and locally. As part of this, some Dockerfiles install this binary so that it can be run from the container. While the binary installs ok when building on an M1 mac, running `ecs-upload-task` causes an emulation error. Installing the correct binary should resolve this in order to cover all the use cases of `ecs-upload-task`